### PR TITLE
Fix CI path and README links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: xu-cheng/latex-action@v4
         with:
-          root_file: docs/main.tex
+          working_directory: docs
+          root_file: main.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
       - name: Rename PDF
-        run: mv docs/main.pdf WWI_SQL_Exercises.pdf
+        working-directory: docs
+        run: mv main.pdf ../WWI_SQL_Exercises.pdf
       - uses: actions/upload-artifact@v4
         with:
           name: WWI_SQL_Exercises

--- a/README.md
+++ b/README.md
@@ -54,14 +54,12 @@ Prefer a browser? Import the repo into **Overleaf** and press *Re-compile*.
 .
 ├── docs/
 │   └── main.tex         # LaTeX source for the exercises PDF
-├── sql/
-│   ├── 1-CustomerNamesAndCategories.sql
-│   ├── 2-RetrieveFullNamesAndEmailOfEmployee.sql
-│   ├── ...
-│   └── 20-ListAllStockItemsWithTheirGroups.sql
 ├── .github/workflows/
 │   └── ci.yml
-└── README.md
+├── 1-CustomerNamesAndCategories.sql
+├── 2-RetrieveFullNamesAndEmailOfEmployee.sql
+├── ...
+└── 20-ListAllStockItemsWithTheirGroups.sql
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fix workflow to build docs/main.tex from docs directory
- repair README badge links and update repository structure section

## Testing
- `latexmk -version` *(fails: command not found)*
- `pdflatex --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f73832188329913c25b973f49589